### PR TITLE
Upgrade http4s 0.16.6a

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -4,7 +4,7 @@ name := "$name;format="norm"$"
 version := "0.1.0-SNAPSHOT"
 scalaVersion := "$scala_version$"
 
-val circeVersion = "0.8.0"
+val circeVersion = "0.9.3"
 val http4sVersion = "$http4s_version$"
 val grafterVersion = "$grafter_version$"
 val logbackVersion = "1.2.3"

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -3,6 +3,6 @@ name = grafter-http4s-example
 organization = com.example
 package = $organization$.$name;format="norm,word"$
 
-scala_version = 2.12.3
-http4s_version = 0.15.16a
-grafter_version = 2.1.0
+scala_version = 2.12.6
+http4s_version = 0.16.6a
+grafter_version = 2.6.1

--- a/src/main/g8/project/build.properties
+++ b/src/main/g8/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=1.2.3

--- a/src/main/g8/src/main/scala/$package__packaged$/repository/ItemsRepository.scala
+++ b/src/main/g8/src/main/scala/$package__packaged$/repository/ItemsRepository.scala
@@ -1,7 +1,7 @@
 package $package$.repository
 
 import $package$.main.ApplicationConfig
-import org.zalando.grafter.macros.reader
+import org.zalando.grafter.macros.readerOf
 
-@reader[ApplicationConfig]
+@readerOf[ApplicationConfig]
 case class ItemsRepository()


### PR DESCRIPTION
Every new version of http4s has a big change, the current template code is out of dated. This PR update http4s to 0.16. It is out of date already. However, it's still worth to keep as a version history

Can you merge it and create 0.16 branch? Thanks

